### PR TITLE
Add mov to list of valid video files

### DIFF
--- a/preprocess/colmap_pipeline.py
+++ b/preprocess/colmap_pipeline.py
@@ -539,7 +539,7 @@ def do_one(source_path, n_images, clean=False, minimal=False, full=False, averag
     files_n = os.listdir(source_path)
     video_n = None
     for f in files_n:
-        if f.split(".")[-1] in ["mp4", "MP4"]:
+        if f.lower().endswith(('.mp4', '.mov', '.avi')):
             video_n = f
             break
 
@@ -682,7 +682,7 @@ def do_one_robust(source_path, n_images, clean=False, minimal=False, full=False,
     files_n = os.listdir(source_path)
     video_n = None
     for f in files_n:
-        if f.split(".")[-1] in ["mp4", "MP4"]:
+        if f.lower().endswith(('.mp4', '.mov', '.avi')):
             video_n = f
             break
 


### PR DESCRIPTION
This PR adds support to `preprocess/colmap_pipeline.py` for the same list of video files as in https://github.com/bidbest/video_to_3dgs/blob/173783b4619f0f60f8d5d67c7ead0604f7918f3e/do_all.py#L94